### PR TITLE
fix, tidy: cmake project was failing to configure.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 project(jkj_fp
         VERSION 0.0.1
         LANGUAGES CXX)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # ---- Includes ----
 
@@ -69,6 +70,7 @@ target_include_directories(jkj_fp_charconv
         "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 
 target_compile_features(jkj_fp_charconv PUBLIC cxx_std_17)
+set_target_properties(jkj_fp_charconv PROPERTIES FOLDER fp)
 
 # ---- Install ----
 

--- a/subproject/3rdparty/grisu_exact/CMakeLists.txt
+++ b/subproject/3rdparty/grisu_exact/CMakeLists.txt
@@ -22,3 +22,4 @@ if (MSVC)
               $<$<NOT:$<CXX_COMPILER_ID:Clang>>:/experimental:newLambdaProcessor>
               $<$<CONFIG:Release>:/GL>)
 endif()
+set_target_properties(grisu_exact PROPERTIES FOLDER fp/extern)

--- a/subproject/3rdparty/ryu/CMakeLists.txt
+++ b/subproject/3rdparty/ryu/CMakeLists.txt
@@ -23,3 +23,4 @@ if (MSVC)
     target_compile_options(ryu PUBLIC
               /Zi $<$<CONFIG:Release>:/GL>)
 endif()
+set_target_properties(ryu PROPERTIES FOLDER fp/extern)

--- a/subproject/3rdparty/schubfach/CMakeLists.txt
+++ b/subproject/3rdparty/schubfach/CMakeLists.txt
@@ -20,3 +20,4 @@ if (MSVC)
               /Zi /permissive-
               $<$<CONFIG:Release>:/GL>)
 endif()
+set_target_properties(schubfach PROPERTIES FOLDER fp/extern)

--- a/subproject/benchmark/CMakeLists.txt
+++ b/subproject/benchmark/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 project(jkj_fp_benchmark LANGUAGES CXX)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # ---- Add dependencies ----
 
@@ -31,147 +32,88 @@ if (NOT TARGET fmt)
 endif()
 
 
+function(fp_add_benchmark NAME)
+  cmake_parse_arguments(FPBM "" "" "SOURCES;INCLUDES;LIBRARIES" ${ARGN})
+  add_executable(${NAME})
+  target_include_directories(${NAME} PRIVATE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include> ${FPBM_INCLUDES})
+  target_sources(${NAME} PRIVATE ${FPBM_SOURCES})
+  target_link_libraries(${NAME} PRIVATE ${FPBM_LIBRARIES})
+  target_compile_features(${NAME} PRIVATE cxx_std_17)
+  # ---- MSVC Specifics ----
+  if (MSVC)
+      # No need to not generate PDB
+      # /permissive- should be the default
+      # The compilation will fail without /experimental:newLambdaProcessor
+      # See also https://gitlab.kitware.com/cmake/cmake/-/issues/16478
+      target_compile_options(${NAME} PUBLIC
+              /Zi /permissive-
+              $<$<NOT:$<CXX_COMPILER_ID:Clang>>:/experimental:newLambdaProcessor>
+              $<$<CONFIG:Release>:/GL>)
+      target_link_options(${NAME} PUBLIC $<$<CONFIG:Release>:/LTCG> /DEBUG:FASTLINK)
+      set_target_properties(${NAME} PROPERTIES
+            VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
+  endif()
+  set_target_properties(${NAME} PROPERTIES FOLDER fp/benchmark)
+endfunction()
+
+
 # ---- Fixed-precision Benchmark ----
 
-add_executable(to_chars_fixed_precision_benchmark
+fp_add_benchmark(to_chars_fixed_precision_benchmark
+    SOURCES
         include/to_chars_fixed_precision_benchmark.h
         source/to_chars_fixed_precision_benchmark.cpp
         source/fp_to_chars_fixed_precision.cpp
         source/ryu_fixed_precision.cpp
-        source/fmt_fixed_precision.cpp)
-
-target_compile_features(to_chars_fixed_precision_benchmark PRIVATE cxx_std_17)
-
-target_include_directories(to_chars_fixed_precision_benchmark
-        PRIVATE
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
-
-target_link_libraries(to_chars_fixed_precision_benchmark
-        PRIVATE
+        source/fmt_fixed_precision.cpp
+    LIBRARIES  
         ryu::ryu
         fmt::fmt
         jkj_fp::common
         jkj_fp::charconv)
 
-if (MSVC)
-    # No need to not generate PDB
-    # /permissive- should be the default
-    # The compilation will fail without /experimental:newLambdaProcessor
-    # See also https://gitlab.kitware.com/cmake/cmake/-/issues/16478
-    target_compile_options(to_chars_fixed_precision_benchmark PUBLIC
-              /Zi /permissive-
-              $<$<NOT:$<CXX_COMPILER_ID:Clang>>:/experimental:newLambdaProcessor>
-              $<$<CONFIG:Release>:/GL>)
-    target_link_options(to_chars_fixed_precision_benchmark PUBLIC $<$<CONFIG:Release>:/LTCG> /DEBUG:FASTLINK)
-    set_target_properties(to_chars_fixed_precision_benchmark PROPERTIES 
-            VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
-endif()
-
 
 # ---- Shortest-roundtrip Benchmark ----
 
-add_executable(to_chars_shortest_roundtrip_benchmark
+fp_add_benchmark(to_chars_shortest_roundtrip_benchmark
+    SOURCES
         include/to_chars_shortest_roundtrip_benchmark.h
         source/to_chars_shortest_roundtrip_benchmark.cpp
         source/fp_to_chars_shortest_roundtrip.cpp
         source/ryu_shortest_roundtrip.cpp
         source/grisu_exact_shortest_roundtrip.cpp
-        source/schubfach_shortest_roundtrip.cpp)
-
-target_compile_features(to_chars_shortest_roundtrip_benchmark PRIVATE cxx_std_17)
-
-target_include_directories(to_chars_shortest_roundtrip_benchmark
-        PRIVATE
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
-
-target_link_libraries(to_chars_shortest_roundtrip_benchmark
-        PRIVATE
+        source/schubfach_shortest_roundtrip.cpp
+    LIBRARIES
         ryu::ryu
         grisu_exact::grisu_exact
         schubfach::schubfach
         jkj_fp::common
         jkj_fp::charconv)
 
-if (MSVC)
-    # No need to not generate PDB
-    # /permissive- should be the default
-    # The compilation will fail without /experimental:newLambdaProcessor
-    # See also https://gitlab.kitware.com/cmake/cmake/-/issues/16478
-    target_compile_options(to_chars_shortest_roundtrip_benchmark PUBLIC
-              /Zi /permissive-
-              $<$<NOT:$<CXX_COMPILER_ID:Clang>>:/experimental:newLambdaProcessor>
-              $<$<CONFIG:Release>:/GL>)
-    target_link_options(to_chars_shortest_roundtrip_benchmark PUBLIC $<$<CONFIG:Release>:/LTCG> /DEBUG:FASTLINK)
-    set_target_properties(to_chars_shortest_roundtrip_benchmark PROPERTIES 
-            VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
-endif()
-
 
 # ---- Limited-precision from_chars Benchmark ----
 
-add_executable(from_chars_limited_precision_benchmark
+fp_add_benchmark(from_chars_limited_precision_benchmark
+    SOURCES
         include/from_chars_limited_precision_benchmark.h
         source/from_chars_limited_precision_benchmark.cpp
         source/fp_from_chars_limited_precision.cpp
-        source/ryu_stof.cpp)
-
-target_compile_features(from_chars_limited_precision_benchmark PRIVATE cxx_std_17)
-
-target_include_directories(from_chars_limited_precision_benchmark
-        PRIVATE
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
-
-target_link_libraries(from_chars_limited_precision_benchmark
-        PRIVATE
+        source/ryu_stof.cpp
+    LIBRARIES
         ryu::ryu
         jkj_fp::common
         jkj_fp::charconv)
 
-if (MSVC)
-    # No need to not generate PDB
-    # /permissive- should be the default
-    # The compilation will fail without /experimental:newLambdaProcessor
-    # See also https://gitlab.kitware.com/cmake/cmake/-/issues/16478
-    target_compile_options(from_chars_limited_precision_benchmark PUBLIC
-              /Zi /permissive-
-              $<$<NOT:$<CXX_COMPILER_ID:Clang>>:/experimental:newLambdaProcessor>
-              $<$<CONFIG:Release>:/GL>)
-    target_link_options(from_chars_limited_precision_benchmark PUBLIC $<$<CONFIG:Release>:/LTCG> /DEBUG:FASTLINK)
-    set_target_properties(from_chars_limited_precision_benchmark PROPERTIES 
-            VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
-endif()
-
 
 # ---- Unlimited-precision from_chars Benchmark ----
 
-add_executable(from_chars_unlimited_precision_benchmark
+fp_add_benchmark(from_chars_unlimited_precision_benchmark
+    SOURCES
         include/from_chars_unlimited_precision_benchmark.h
         source/from_chars_unlimited_precision_benchmark.cpp
         source/fp_from_chars_unlimited_precision.cpp
         source/std_from_chars.cpp
-        source/stod.cpp)
-
-target_compile_features(from_chars_unlimited_precision_benchmark PRIVATE cxx_std_17)
-
-target_include_directories(from_chars_unlimited_precision_benchmark
-        PRIVATE
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
-
-target_link_libraries(from_chars_unlimited_precision_benchmark
-        PRIVATE
+        source/stod.cpp
+    LIBRARIES
         jkj_fp::common
         jkj_fp::charconv)
-
-if (MSVC)
-    # No need to not generate PDB
-    # /permissive- should be the default
-    # The compilation will fail without /experimental:newLambdaProcessor
-    # See also https://gitlab.kitware.com/cmake/cmake/-/issues/16478
-    target_compile_options(from_chars_unlimited_precision_benchmark PUBLIC
-              /Zi /permissive-
-              $<$<NOT:$<CXX_COMPILER_ID:Clang>>:/experimental:newLambdaProcessor>
-              $<$<CONFIG:Release>:/GL>)
-    target_link_options(from_chars_unlimited_precision_benchmark PUBLIC $<$<CONFIG:Release>:/LTCG> /DEBUG:FASTLINK)
-    set_target_properties(from_chars_unlimited_precision_benchmark PROPERTIES 
-            VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
-endif()

--- a/subproject/meta/CMakeLists.txt
+++ b/subproject/meta/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 project(jkj_fp_meta LANGUAGES CXX)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 include(FetchContent)
 if (NOT TARGET jkj_fp)
@@ -41,6 +42,7 @@ function(meta_exe NAME)
       set_target_properties(${NAME} PROPERTIES 
             VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
   endif()
+  set_target_properties(${NAME} PROPERTIES FOLDER fp/meta)
 endfunction()
 
 meta_exe(to_chars_fixed_precision_live_test jkj_fp::charconv)

--- a/subproject/test/CMakeLists.txt
+++ b/subproject/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
 project(jkj_fp_tests LANGUAGES CXX)
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 # ---- Add dependencies ----
 
@@ -25,26 +26,40 @@ endif()
 
 enable_testing()
 
-function(add_test NAME)
-  cmake_parse_arguments(TEST "CHARCONV;RYU" "NAME" "" ${ARGN})
+# setup convenience umbrella targets
+add_custom_target(fp-test-build)       # target for building all tests
+add_custom_target(fp-test-run          # target for running all tests
+  COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C $<CONFIG> ${FP_CTEST_OPTIONS}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS fp-test-build)
+add_custom_target(fp-test-run-verbose  # target for running all tests in verbose mode
+  COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C $<CONFIG> ${FP_CTEST_OPTIONS} -VV
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS fp-test-build)
+set_target_properties(fp-test-build PROPERTIES FOLDER fp/test)
+set_target_properties(fp-test-run PROPERTIES FOLDER fp/test)
+set_target_properties(fp-test-run-verbose PROPERTIES FOLDER fp/test)
+if(NOT TARGET test)  # maybe this target is defined in a higher level project
+  add_custom_target(test)
+  set_target_properties(test PROPERTIES FOLDER fp/test)
+endif()
+add_dependencies(test fp-test-run)
+
+function(fp_add_test NAME)
+  cmake_parse_arguments(TEST "CHARCONV;RYU" "" "" ${ARGN})
   if(TEST_CHARCONV)
     set(jkj_fp jkj_fp::charconv)
   else()
     set(jkj_fp jkj_fp::fp)
   endif()
-
   add_executable(${NAME} source/${NAME}.cpp)
-
+  add_dependencies(fp-test-build ${NAME})
   target_link_libraries(${NAME} PRIVATE ${jkj_fp} jkj_fp::common)
-
   if(TEST_RYU)
     target_link_libraries(${NAME} PRIVATE ryu::ryu)
   endif()
-
   target_compile_features(${NAME} PRIVATE cxx_std_17)
-
-  _add_test(NAME ${NAME} COMMAND ${NAME})
-
+  add_test(NAME ${NAME} COMMAND $<TARGET_FILE:${NAME}>)
   # ---- MSVC Specifics ----
   if (MSVC)
       # No need to not generate PDB
@@ -56,20 +71,21 @@ function(add_test NAME)
               $<$<NOT:$<CXX_COMPILER_ID:Clang>>:/experimental:newLambdaProcessor>
               $<$<CONFIG:Release>:/GL>)
       target_link_options(${NAME} PUBLIC $<$<CONFIG:Release>:/LTCG> /DEBUG:FASTLINK)
-      set_target_properties(${NAME} PROPERTIES 
+      set_target_properties(${NAME} PROPERTIES
             VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
   endif()
+  set_target_properties(${NAME} PROPERTIES FOLDER fp/test)
 endfunction()
 
-add_test(test_bigint)
-add_test(test_minmax_euclid)
-add_test(test_policy_holder)
-add_test(verify_log_computation)
-add_test(dragonbox_test_all_shorter_interval_cases CHARCONV RYU)
-add_test(dragonbox_uniform_random_test CHARCONV RYU)
-add_test(dragonbox_verify_fast_multiplication)
-add_test(dragonbox_verify_magic_division)
-add_test(dragonbox_dooly_binary32_exhaustive_joint_test RYU)
-add_test(dragonbox_dooly_binary64_uniform_random_joint_test RYU)
-add_test(ryu_printf_uniform_random_test CHARCONV RYU)
-add_test(ryu_printf_dooly_uniform_random_joint_test CHARCONV RYU)
+fp_add_test(test_bigint)
+fp_add_test(test_minmax_euclid)
+fp_add_test(test_policy_holder)
+fp_add_test(verify_log_computation)
+fp_add_test(dragonbox_test_all_shorter_interval_cases CHARCONV RYU)
+fp_add_test(dragonbox_uniform_random_test CHARCONV RYU)
+fp_add_test(dragonbox_verify_fast_multiplication)
+fp_add_test(dragonbox_verify_magic_division)
+fp_add_test(dragonbox_dooly_binary32_exhaustive_joint_test RYU)
+fp_add_test(dragonbox_dooly_binary64_uniform_random_joint_test RYU)
+fp_add_test(ryu_printf_uniform_random_test CHARCONV RYU)
+fp_add_test(ryu_printf_dooly_uniform_random_joint_test CHARCONV RYU)


### PR DESCRIPTION
the main point is fixing a problem in `add_test()` where NAME was not available (it cannot be both an explicit macro argument and an entry to `cmake_parse_arguments()`)

Also, refactored some boilerplate cmake code to functions, and organized the project into folders:

![image](https://user-images.githubusercontent.com/325344/98589030-8e398200-22c4-11eb-8ad2-1e95a7b88041.png)
